### PR TITLE
Added domain setting to google analytics provider

### DIFF
--- a/src/providers/ga/ga-test.js
+++ b/src/providers/ga/ga-test.js
@@ -21,7 +21,7 @@
         analytics.initialize({
             'Google Analytics' : {
               'trackingId' : 'x',
-              'domainName' : 'example.com'
+              'domain' : 'example.com'
             }
         });
         expect(

--- a/src/providers/ga/ga.js
+++ b/src/providers/ga/ga.js
@@ -8,7 +8,7 @@ analytics.addProvider('Google Analytics', {
         anonymizeIp             : false,
         enhancedLinkAttribution : false,
         siteSpeedSampleRate     : null,
-        domainName              : null,
+        domain                  : null,
         trackingId              : null
     },
 
@@ -35,8 +35,8 @@ analytics.addProvider('Google Analytics', {
         if (analytics.utils.isNumber(this.settings.siteSpeedSampleRate)) {
             _gaq.push(['_setSiteSpeedSampleRate', this.settings.siteSpeedSampleRate]);
         }
-        if(this.settings.domainName) {
-            _gaq.push(['_setDomainName', this.settings.domainName]);
+        if(this.settings.domain) {
+            _gaq.push(['_setDomainName', this.settings.domain]);
         }
         if(this.settings.anonymizeIp) {
             _gaq.push(['_gat._anonymizeIp']);


### PR DESCRIPTION
When using GA across multiple subdomains you need specify a domain parameter on initialization. I just added this, as well as a test. 

The test is a little awkward because in chai, `expect([[1,2], [3,4]]).to.include([1,2])` doesn't work like you'd hope. 
