### PR TITLE
Fix crash in IE8

### DIFF
--- a/src/providers/gosquared/gosquared.js
+++ b/src/providers/gosquared/gosquared.js
@@ -62,7 +62,7 @@ analytics.addProvider('GoSquared', {
 
     pageview : function () {
         window.GoSquared.DefaultTracker.TrackView();
-    },
+    }
 
 });
 


### PR DESCRIPTION
Old versions of IE can't deal with unnecessary commas it seems.
