### PR TITLE
Add arguments to ga.js: value and noninteraction

### DIFF
--- a/src/providers/ga/ga.js
+++ b/src/providers/ga/ga.js
@@ -64,7 +64,9 @@ analytics.addProvider('Google Analytics', {
             '_trackEvent',
             properties.category || 'All',
             event,
-            properties.label
+            properties.label,
+            properties.value,
+            properties.noninteraction
         ]);
     },
 


### PR DESCRIPTION
When using segment.io and calling ga, there are two missing arguments (which I take advantage of)
So I added those two calls:
 properties.value,
 properties.noninteraction
