### PR TITLE
check for company in traits before adding to settings

### DIFF
--- a/src/providers/intercom.js
+++ b/src/providers/intercom.js
@@ -58,7 +58,7 @@ module.exports = Provider.extend({
     if (traits) {
       settings.email = traits.email;
       settings.name = traits.name;
-      settings.company = traits.company;
+      if (traits.company) settings.company = traits.company;
       if (traits.created) settings.created_at = Math.floor(traits.created/1000);
     }
 


### PR DESCRIPTION
Noticed the check in place for 'created' and the same should be in place for 'company' as it's an optional setting for Intercom.
