### PR TITLE
mixpanel: adds $referrer and $initial_referrer aliases, fixes #165

### DIFF
--- a/src/providers/mixpanel.js
+++ b/src/providers/mixpanel.js
@@ -62,14 +62,16 @@ module.exports = Provider.extend({
   identify : function (userId, traits) {
     // Alias the traits' keys with dollar signs for Mixpanel's API.
     alias(traits, {
-      'created'   : '$created',
-      'email'     : '$email',
-      'firstName' : '$first_name',
-      'lastName'  : '$last_name',
-      'lastSeen'  : '$last_seen',
-      'name'      : '$name',
-      'username'  : '$username',
-      'phone'     : '$phone'
+      'created'           : '$created',
+      'email'             : '$email',
+      'firstName'         : '$first_name',
+      'lastName'          : '$last_name',
+      'lastSeen'          : '$last_seen',
+      'name'              : '$name',
+      'username'          : '$username',
+      'phone'             : '$phone',
+      'referrer'          : '$referrer',
+      'initial_referrer'  : '$initial_referrer'
     });
 
     // Finally, call all of the identify equivalents. Verify certain calls


### PR DESCRIPTION
We're looking to call .identify when cookies are cleared and a user is logged back in; to preserve referrer settings in Mixpanel People on subsequent identify calls we'd like to pass in original referrer and initial_referrer values that we're saving server-side.