### PR TITLE
Adds allowLinker and autoLink to google-analytics.initializeUniversal() ...

### DIFF
--- a/src/providers/google-analytics.js
+++ b/src/providers/google-analytics.js
@@ -105,10 +105,17 @@ module.exports = Provider.extend({
       createOpts.cookieDomain = options.domain || 'none';
     if (type(options.siteSpeedSampleRate) === 'number')
       createOpts.siteSpeedSampleRate = options.siteSpeedSampleRate;
+    if (options.allowLinker)
+      createOpts.allowLinker = true;
     if (options.anonymizeIp)
       ga('set', 'anonymizeIp', true);
 
     ga('create', options.trackingId, createOpts);
+
+    if (options.autoLink instanceof Array) {
+      ga('require', 'linker');
+      ga('linker:autoLink', options.autoLink);
+    }
 
     if (options.initialPageview) {
       var path, canon = canonical();


### PR DESCRIPTION
Adds `allowLinker` and `autoLink` to `google-analytics.initializeUniversal()` `options` parameter.
- `allowLinker` is boolean and includes `{allowLinker: true}` if set to `true`.
- `autoLink` should be an Array of domain names, and includes the linker module then enables autolinking for links/forms to the `autoLink` domains. 

See https://developers.google.com/analytics/devguides/collection/analyticsjs/cross-domain
