### PR TITLE
Bugfix by cloning arguments before each invoke

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -430,7 +430,8 @@ Analytics.prototype._invoke = function (method, args) {
   var options = args[args.length-1]; // always the last one
   each(this._integrations, function (name, integration) {
     if (!isEnabled(integration, options)) return;
-    integration.invoke.apply(integration, args);
+    var clonedArgs = clone(args)
+    integration.invoke.apply(integration, clonedArgs);
   });
   return this;
 };

--- a/test/core/analytics.js
+++ b/test/core/analytics.js
@@ -220,6 +220,13 @@ describe('#_invoke', function () {
     assert(this.invokeSpy.calledWith('identify', 'id', { trait: true }));
   });
 
+  it('should clone arguments before invoking each integration', function () {
+    var traits = { foo: 1 };
+    analytics._invoke('identify', 'id', traits);
+    assert(this.invokeSpy.alwaysCalledWith('identify', 'id', traits));
+    assert(this.invokeSpy.neverCalledWith('identify', 'id', sinon.match.same(traits)));
+  });
+
   it('shouldnt call a method when the `all` option is false', function () {
     analytics._invoke('identify', { providers: { all: false }});
     assert(!this.invokeSpy.called);


### PR DESCRIPTION
I had Mixpanel and Customer.io integrations setup.

But due to this bug Customer.io was never receiving the `email` trait, since the Mixpanel integration clobbered the original `email` trait when it converted it to `$email`.

Fix + test included.

Note that the `_invoke` function actually had the comment correct, but the code wasn't doing what it said:

> Call a `method` on all of initialized integrations, passing clones of arguments

You may also want to add a higher level functionality test (rather than just the raw mechanics of `_invoke`)
