### PR TITLE
mixpanel deprecated the track_pageview method, removing it!

### DIFF
--- a/lib/integrations/mixpanel.js
+++ b/lib/integrations/mixpanel.js
@@ -142,13 +142,10 @@ Mixpanel.prototype.track = function (event, properties, options) {
 /**
  * Pageview.
  *
- * https://mixpanel.com/help/reference/javascript-full-api-reference#mixpanel.track_pageview
- *
  * @param {String} url (optional)
  */
 
 Mixpanel.prototype.pageview = function (url) {
-  window.mixpanel.track_pageview(url); // shows up in streams regardless
   if (!this.options.pageview) return;
 
   this.track('Loaded a Page', {


### PR DESCRIPTION
track_pageview method was used for their Streams report, but the new Live view that replaced Streams does not listen to the track_pageview method. Mixpanel support let me know that track_pageview is deprecated and will be removed soon! Removing the reference here to keep up to date and avoid pounding their servers unnecessarily :)
