### PR TITLE
Fixing two issues with google analytics universal

### DIFF
--- a/lib/integrations/google-analytics.js
+++ b/lib/integrations/google-analytics.js
@@ -76,15 +76,16 @@ GA.prototype.initialize = function (options, ready) {
   });
   window.ga.l = new Date().getTime();
 
-  // anonymize before initializing
-  if (options.anonymizeIp) window.ga('set', 'anonymizeIp', true);
-
   // initialize
   window.ga('create', options.trackingId, {
-    cookieDomain: options.domain,
+    cookieDomain: options.domain || GA.prototype.defaults.domain, // to protect against empty string
     siteSpeedSampleRate: options.siteSpeedSampleRate,
     allowLinker: true
   });
+
+  // anonymize after initializing, otherwise a warning is shown
+  // in google analytics debugger
+  if (options.anonymizeIp) window.ga('set', 'anonymizeIp', true);
 
   // track a pageview with the canonical url
   if (options.initialPageview) {


### PR DESCRIPTION
ip anonymization was trying to be set before initialization, resulting in a warning in google analytics debugger.

also protecting against an empty cookie domain string, 'none' is the right choice there.

thanks to @Swaagie for reporting these issues!
