### PR TITLE
Set 0.0.0.0 to also be localhost

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -13756,7 +13756,7 @@ Cookie.prototype.options = function (options) {
   var domain = '.' + topDomain(window.location.href);
 
   // localhost cookies are special: http://curl.haxx.se/rfc/cookie_spec.html
-  if (domain === '.localhost') domain = '';
+  if (domain === '.localhost' || domain === '.0.0.0.0') domain = '';
 
   defaults(options, {
     maxage: 31536000000, // default to a year


### PR DESCRIPTION
Analytics.js doesn't save a session cookie when the page is served from 0.0.0.0. Yeoman's webapp generators default Gruntfile.js suggests using 0.0.0.0 instead of localhost when you want to share from your comptuer so I imagine this is fairly common (https://github.com/yeoman/generator-webapp/blob/master/app/templates/Gruntfile.js#L85). A better fix would be to make it handle ip in a more robust way.
