### PR TITLE
make-test: make sure we use the correct phantomjs(1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ DUO = $(BINS)/duo
 
 PHANTOM= $(BINS)/mocha-phantomjs \
 	--setting local-to-remote-url-access=true \
-	--setting-web-security=false
+	--setting-web-security=false \
+	--path $(BINS)/phantomjs
 
 #
 # Default target.
@@ -41,9 +42,9 @@ test: $(TESTS) server
 
 #
 # Test in the browser.
-# 
+#
 # On the link press `cmd + doubleclick`.
-# 
+#
 
 test-browser: $(TESTS) server
 	@echo open $(TEST)


### PR DESCRIPTION
ATM `mocha-phantomjs` works only if `phantoms(1)` is installed and is in your `$PATH` this fixes the problem.

cc @lancejpollard @ianstormtaylor 
