### PR TITLE
allow adding integrations in a test-friendly way

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -117,11 +117,6 @@ Analytics.prototype.initialize = function (settings, options) {
 
   this._options(options);
   this._readied = false;
-  this._integrations = {};
-
-  // load user now that options are set
-  user.load();
-  group.load();
 
   // clean unknown integrations from settings
   var self = this;
@@ -130,23 +125,33 @@ Analytics.prototype.initialize = function (settings, options) {
     if (!Integration) delete settings[name];
   });
 
+  // add integrations
+  each(settings, function (name, opts) {
+    var Integration = self.Integrations[name];
+    var integration = new Integration(clone(opts));
+    self.add(integration);
+  });
+
+  var integrations = this._integrations;
+
+  // load user now that options are set
+  user.load();
+  group.load();
+
   // make ready callback
-  var ready = after(size(settings), function () {
+  var ready = after(size(integrations), function () {
     self._readied = true;
     self.emit('ready');
   });
 
   // initialize integrations, passing ready
-  each(settings, function (name, opts) {
-    var Integration = self.Integrations[name];
+  each(integrations, function (name, integration) {
     if (options.initialPageview && opts.initialPageview === false) {
-      Integration.prototype.page = after(2, Integration.prototype.page);
+      integration.page = after(2, integration.page);
     }
 
-    var integration = new Integration(clone(opts));
     integration.once('ready', ready);
     integration.initialize();
-    self._integrations[name] = integration;
   });
 
   // backwards compat with angular plugin.
@@ -154,6 +159,17 @@ Analytics.prototype.initialize = function (settings, options) {
   this.initialized = true;
 
   this.emit('initialize', settings, options);
+  return this;
+};
+
+/**
+ * Add an integration.
+ *
+ * @param {Integration} integration
+ */
+
+Analytics.prototype.add = function(integration){
+  this._integrations[integration.name] = integration;
   return this;
 };
 

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -40,6 +40,10 @@ describe('Analytics', function () {
   afterEach(function () {
     user.reset();
     group.reset();
+    // clear the hash
+    if (window.history && window.history.pushState) { 
+      window.history.pushState('', '', window.location.pathname);
+    }
   });
 
   it('should setup an Integrations object', function () {
@@ -107,10 +111,13 @@ describe('Analytics', function () {
       assert(!analytics._readied);
     });
 
-    it('should empty analytics._integrations', function () {
-      analytics._integrations = { Integration: {} };
+    it('should add integration instance', function(done){
+      Test.readyOnInitialize();
+      analytics.addIntegration(Test);
+      analytics.ready(done);
+      var test = new Test(settings.Test);
+      analytics.add(test);
       analytics.initialize();
-      assert(equal(analytics._integrations, {}));
     });
 
     it('should listen on integration ready events', function (done) {


### PR DESCRIPTION
@yields @ianstormtaylor this would makes things easier to test, so we can instantiate the integration and use it directly in tests without any tricky workarounds.

The test before-blocks would look something like this:

``` js
describe('before loading', function(){
  beforeEach(function(){
    analytics = new Analytics;
    mixpanel = new Mixpanel.Integration(options);
    analytics.use(plugin);
    analytics.use(tester);
    analytics.add(mixpanel);
    analytics.spy(mixpanel, 'load');
  });
});

describe('after loading', function(){
  before(function(done){
    analytics = new Analytics;
    mixpanel = new Mixpanel.Integration(options);
    analytics.use(plugin);
    analytics.use(tester);
    analytics.add(mixpanel);
    analytics.once('ready', done);
    analytics.initialize();
    analytics.page();
  });
});
```

instead of this:

``` js
describe('before loading', function(){
  beforeEach(function(){
    analytics = new Analytics;
    analytics.use(plugin);
    analytics.use(tester);
    analytics.spy(Mixpanel.Integration.prototype, 'load');
    mixpanel = analytics.integration('Mixpanel');
  });
});

describe('after loading', function(){
  before(function(done){
    analytics = new Analytics;
    analytics.use(plugin);
    analytics.use(tester);
    analytics.once('ready', done);
    analytics.initialize(settings);
    analytics.page();
    mixpanel = analytics.integration('Mixpanel');
  });
});
```

All tests pass. The only thing that I changed was removing a test that `this._integrations` got reset. I only case I can seeing that being desired behavior is so you can call `analytics.initialize(settings)` multiple times, but does this ever happen? I can see us wanting to reset that perhaps for tests, but it seems like that type of thing would go into a `.reset()` method or something. If this is desired behavior, what is it used for exactly? That way I can try to figure out a way to still get this `.add` functionality in there to simplify the tests :D

It also seems like with the `.add` method, the describes could be even further simplified.

``` js
describe('Mixpanel', function(){
  beforeEach(function(){
    analytics = new Analytics;
    mixpanel = new Mixpanel.Integration(options);
    analytics.use(plugin);
    analytics.use(tester);
    analytics.add(mixpanel);
  });

  describe('before loading', function(){
    beforeEach(function(){
      analytics.spy(mixpanel, 'load');
    });
  });

  describe('after loading', function(){
    before(function(done){
      analytics.once('ready', done);
      analytics.initialize();
      analytics.page();
    });
  });
});
```

/cc @calvinfo 
