### PR TITLE
throw helpful error when passing string to `trackLink`, closes #389

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -301,6 +301,7 @@ Analytics.prototype.trackLink = function (links, event, properties) {
 
   var self = this;
   each(links, function (el) {
+    if (!is.element(el)) throw new TypeError('Must pass HTMLElement to `analytics.trackLink`.');
     on(el, 'click', function (e) {
       var ev = is.fn(event) ? event(el) : event;
       var props = is.fn(properties) ? properties(el) : properties;
@@ -338,6 +339,7 @@ Analytics.prototype.trackForm = function (forms, event, properties) {
 
   var self = this;
   each(forms, function (el) {
+    if (!is.element(el)) throw new TypeError('Must pass HTMLElement to `analytics.trackForm`.');
     function handler (e) {
       prevent(e);
 

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -962,6 +962,15 @@ describe('Analytics', function () {
       assert(analytics.track.called);
     });
 
+    it('should not accept a string for an element', function () {
+      var str = 'a';
+      assert.throws(function(){
+        analytics.trackLink(str);
+      }, TypeError, 'Must pass HTMLElement to `analytics.trackLink`.');
+      trigger(link, 'click');
+      assert(!analytics.track.called);
+    });
+
     it('should send an event and properties', function () {
       analytics.trackLink(link, 'event', { property: true });
       trigger(link, 'click');
@@ -1040,6 +1049,15 @@ describe('Analytics', function () {
       analytics.trackForm(form);
       trigger(submit, 'click');
       assert(analytics.track.called);
+    });
+
+    it('should not accept a string for an element', function () {
+      var str = 'form';
+      assert.throws(function(){
+        analytics.trackForm(str);
+      }, TypeError, 'Must pass HTMLElement to `analytics.trackForm`.');
+      trigger(submit, 'click');
+      assert(!analytics.track.called);
     });
 
     it('should send an event and properties', function () {


### PR DESCRIPTION
/cc @reinpk 
