### PR TITLE
fix: prevent anonymousId from changing when user id is reset

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -56,6 +56,12 @@ inherit(User, Entity);
  *      user.id('foo');
  *      assert.equal(anonId, user.anonymousId());
  *
+ *      // didn't change because the user id changed to null.
+ *      anonId = user.anonymousId();
+ *      user.id('foo');
+ *      user.id(null);
+ *      assert.equal(anonId, user.anonymousId());
+ *
  *     // change because the user had previous id.
  *     anonId = user.anonymousId();
  *     user.id('foo');
@@ -71,7 +77,7 @@ User.prototype.id = function(id){
   var prev = this._getId();
   var ret = Entity.prototype.id.apply(this, arguments);
   if (null == prev) return ret;
-  if (prev != id) this.anonymousId(null);
+  if (prev != id && id) this.anonymousId(null);
   return ret;
 };
 

--- a/test/user.js
+++ b/test/user.js
@@ -113,6 +113,14 @@ describe('user', function () {
         assert.notEqual(prev, user.anonymousId());
         assert.equal(36, user.anonymousId().length);
       });
+
+      it('should not reset anonymousId if the user id changed to null', function(){
+        var prev = user.anonymousId();
+        user.id('foo');
+        user.id(null);
+        assert.equal(prev, user.anonymousId());
+        assert.equal(36, user.anonymousId().length);
+      });
     });
 
     describe('when chrome-extension:', function(){


### PR DESCRIPTION
cc @calvinfo 
