### PR TITLE
Add noConflict

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,16 +5,24 @@
  * (C) 2013 Segment.io Inc.
  */
 
+var _analytics = window.analytics;
 var Integrations = require('analytics.js-integrations');
 var Analytics = require('./analytics');
 var each = require('each');
-
 
 /**
  * Expose the `analytics` singleton.
  */
 
 var analytics = module.exports = exports = new Analytics();
+
+/**
+ * Ensure we can recover previous window.analytics
+ */
+analytics.noConflict = function() {
+  window.analytics = _analytics;
+  return analytics;
+};
 
 /**
  * Expose require

--- a/test/index.js
+++ b/test/index.js
@@ -20,4 +20,11 @@ describe('analytics', function () {
       assert(a.name == b.name);
     });
   });
+
+  it('should restore original with noConflict()', function () {
+    var actual = analytics.noConflict();
+    assert(actual == analytics);
+    assert(actual != window.analytics);
+    window.analytics = actual;
+  });
 });


### PR DESCRIPTION
Ensure an analytics.js consumer can recover a previously defined window.analytics.