### PR TITLE
Add noConflict to Analytics.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@
  * (C) 2013 Segment.io Inc.
  */
 
+var _analytics = window.analytics;
 var Integrations = require('analytics.js-integrations');
 var Analytics = require('./analytics');
 var each = require('each');
@@ -15,6 +16,14 @@ var each = require('each');
  */
 
 var analytics = module.exports = exports = new Analytics();
+
+/**
+ * Ensure we can recover previous window.analytics
+ */
+analytics.noConflict = function() {
+  window.analytics = _analytics;
+  return analytics;
+};
 
 /**
  * Expose require

--- a/test/index.js
+++ b/test/index.js
@@ -20,4 +20,30 @@ describe('analytics', function () {
       assert(a.name == b.name);
     });
   });
+
+  describe('noConflict', function () {
+    beforeEach(function () {
+      analytics = window.analytics;
+    });
+
+    afterEach(function () {
+      window.analytics = analytics;
+    });
+
+    it('should leave window.analytics unchanged', function () {
+      // Overwrite window.analytics with random object
+      var dummy = {dummy: true};
+      window.analytics = dummy;
+      assert(window.analytics == dummy);
+
+      // Unfortunately loading scripts in doesn't work inside a test
+      window.analytics = require('../lib/index.js');
+      assert(window.analytics != dummy);
+
+      var newAnalytics = window.analytics;
+      var noConflictAnalytics = window.analytics.noConflict();
+      assert(window.analytics == dummy);
+      assert(newAnalytics == noConflictAnalytics);
+    });
+  });
 });


### PR DESCRIPTION
Based of @shawnfrench work on noConflict here: https://github.com/segmentio/analytics.js/pull/415

"Ensure an analytics.js consumer can recover a previously defined window.analytics"

@yields @amillet89 @shawnfrench is this test better?