### PR TITLE
Allow trackLink and trackForm to accept options.

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -309,11 +309,12 @@ Analytics.prototype.track = function (event, properties, options, fn) {
  * @param {Element or Array} links
  * @param {String or Function} event
  * @param {Object or Function} properties (optional)
+ * @param {Object} options (optional)
  * @return {Analytics}
  */
 
 Analytics.prototype.trackClick =
-Analytics.prototype.trackLink = function (links, event, properties) {
+Analytics.prototype.trackLink = function (links, event, properties, options) {
   if (!links) return this;
   if (is.element(links)) links = [links]; // always arrays, handles jquery
 
@@ -327,7 +328,7 @@ Analytics.prototype.trackLink = function (links, event, properties) {
         || el.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
         || el.getAttribute('xlink:href');
 
-      self.track(ev, props);
+      self.track(ev, props, options);
 
       if (href && el.target !== '_blank' && !isMeta(e)) {
         prevent(e);
@@ -350,11 +351,12 @@ Analytics.prototype.trackLink = function (links, event, properties) {
  * @param {Element or Array} forms
  * @param {String or Function} event
  * @param {Object or Function} properties (optional)
+ * @param {Object} options (optional)
  * @return {Analytics}
  */
 
 Analytics.prototype.trackSubmit =
-Analytics.prototype.trackForm = function (forms, event, properties) {
+Analytics.prototype.trackForm = function (forms, event, properties, options) {
   if (!forms) return this;
   if (is.element(forms)) forms = [forms]; // always arrays, handles jquery
 
@@ -366,7 +368,7 @@ Analytics.prototype.trackForm = function (forms, event, properties) {
 
       var ev = is.fn(event) ? event(el) : event;
       var props = is.fn(properties) ? properties(el) : properties;
-      self.track(ev, props);
+      self.track(ev, props, options);
 
       self._callback(function () {
         el.submit();

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -1167,10 +1167,10 @@ describe('Analytics', function () {
       assert(!analytics.track.called);
     });
 
-    it('should send an event and properties', function () {
-      analytics.trackLink(link, 'event', { property: true });
+    it('should send an event, properties, and options', function () {
+      analytics.trackLink(link, 'event', { property: true }, { options: true });
       trigger(link, 'click');
-      assert(analytics.track.calledWith('event', { property: true }));
+      assert(analytics.track.calledWith('event', { property: true }, { options: true }));
     });
 
     it('should accept an event function', function () {
@@ -1291,10 +1291,10 @@ describe('Analytics', function () {
       assert(!analytics.track.called);
     });
 
-    it('should send an event and properties', function () {
-      analytics.trackForm(form, 'event', { property: true });
+    it('should send an event, properties, and options', function () {
+      analytics.trackForm(form, 'event', { property: true }, { options: true });
       submit.click();
-      assert(analytics.track.calledWith('event', { property: true }));
+      assert(analytics.track.calledWith('event', { property: true }, { options: true }));
     });
 
     it('should accept an event function', function () {


### PR DESCRIPTION
Adds a fourth, optional argument to trackLink and trackForm called options that is passed directly through to `#track`.

The use case for me is being able to specify integrations, e.g.

``` javascript
analytics.trackLink(document.querySelectorAll("a"), 'Click!', {}, {
  integrations: {
    'All': false,
    'Google Analytics': true
  }
});
```

Addresses #403.