### PR TITLE
:arrow_up: component/cookie@1.1.2

### DIFF
--- a/component.json
+++ b/component.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "avetisk/defaults": "0.0.4",
     "component/clone": "0.1.0",
-    "component/cookie": "1.1.1",
+    "component/cookie": "1.1.2",
     "component/each": "0.0.1",
     "component/emitter": "1.1.0",
     "component/event": "0.1.1",


### PR DESCRIPTION
we ran into an issue on some android environments where even attempting to access `document.cookie` throws an error, making analytics fail. i've updated `component/cookie` to wrap `document.cookie` accesses in a `try/catch`. 

you guys will have to rebuild and test.

i wish it was easy for you guys to reproduce, but here's a screenshot my co-worker got when using a non-minified version of analytics.js:

![screen_shot_2015-04-29_at_4 51 58_pm_720](https://cloud.githubusercontent.com/assets/643505/7403951/db32fb90-ee90-11e4-9116-8522958bd043.png)
