### PR TITLE
Bump component/url dependency version

### DIFF
--- a/component.json
+++ b/component.json
@@ -20,7 +20,7 @@
     "component/inherit": "0.0.2",
     "component/object": "0.0.3",
     "component/querystring": "1.3.0",
-    "component/url": "0.1.0",
+    "component/url": "0.2.0",
     "gjohnson/uuid": "0.0.1",
     "ianstormtaylor/bind": "0.0.2",
     "ianstormtaylor/callback": "0.0.1",


### PR DESCRIPTION
component/url 0.1.0 has several IE-related issues; in particular,
`url.parse(<url>).hostname` inconsistently includes a leading slash,
which results in messy Redshift data. Bumping to 0.2.0 fixes this
issue and generally improves URL handling.