### PR TITLE
Fix 'Analytics is not a function' error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@
  * (C) 2015 Segment.io Inc.
  */
 
-var Analytics = require('segmentio/analytics.js-core');
+var analytics = require('segmentio/analytics.js-core');
 var Integrations = require('./integrations');
 var each = require('each');
 
@@ -13,13 +13,7 @@ var each = require('each');
  * Expose the `analytics` singleton.
  */
 
-var analytics = module.exports = exports = new Analytics();
-
-/**
- * Expose require.
- */
-
-analytics.require = require;
+module.exports = exports = analytics;
 
 /**
  * Expose `VERSION`.


### PR DESCRIPTION
`segmentio/analytics.js-core` already returns a new `Analytics` instance. Invoking it another time was causing an `Analytics is not a function` error.