### PR TITLE
TypeError: Cannot read property 'replace' of undefined

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -8646,6 +8646,7 @@ var camelSplitter = /(.)([A-Z]+)/g;
  */
 
 function uncamelize (string) {
+  if (!string) return '';
   return string.replace(camelSplitter, function (m, previous, uppers) {
     return previous + ' ' + uppers.toLowerCase().split('').join(' ');
   });


### PR DESCRIPTION
we are logging (and have been for some time) many errors from our users in production due to this line (I believe)

here is an example of the dump (from getSentry):
```
TypeError: Cannot read property 'replace' of undefined
  at r(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:9:20241)
  at o(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:9:20133)
  at e.n.map(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:2:10437)
  at e.(anonymous function) [as standardEvents](/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:2:13188)
  at e.d.track(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:4:10929)
  at e.track(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:2:12436)
  at ? (/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:2:10994)
  at c(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:1:19583)
  at u(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:1:19714)
  at e.n.flush(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:2:10968)
  at e.<anonymous>(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:7:19870)
  at e.n(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:7:22769)
  at e.o.emit(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:7:23417)
  at e.n.ready(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:2:11930)
  at ? (/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:7:19870)
  at ? (/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:2:11576)
  at HTMLScriptElement.<anonymous>(/analytics.js/v1/VCdXF6Dpysf0ApZlvfGszIMrngKN5mYR/analytics.min.js:8:28371)
  at apply(raven.js:389:28)
```