### PR TITLE
Add productId to Track prototype for Ecommerce events

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -2754,6 +2754,7 @@ Track.prototype.category = Facade.proxy('properties.category');
  * Ecommerce
  */
 
+Track.prototype.productId = Facade.proxy('properties.product_id') || Facade.proxy('properties.productId');
 Track.prototype.id = Facade.proxy('properties.id');
 Track.prototype.sku = Facade.proxy('properties.sku');
 Track.prototype.tax = Facade.proxy('properties.tax');


### PR DESCRIPTION
Hi,

We are using analytics.js for our tracking as an npm dependency in our e-commerce project.
We are also using the google analytics integration that you provide, i.e. https://github.com/segment-integrations/analytics.js-integration-google-analytics.

It works great except for a few specific events that are throwing errors. Upon investigation, we noticed that some functions in the GA integration try to call `track.productId()` which is undefined in some cases (e.g. for the "Product Viewed" event).

With this change everything works as expected.
We are thinking that maybe this field was just overlooked.

Let me know what you think about this when you get the chance.

Best