### PR TITLE
remove duplicate, incorrect analytics.js quickstart link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,7 +81,6 @@ If you're not sure where to open an issue, feel free to open an issue against th
 [analytics.js]: https://github.com/segmentio/analytics.js
 [unminified]: https://github.com/segmentio/analytics.js/blob/master/analytics.js
 [minified]: https://github.com/segmentio/analytics.js/blob/master/analytics.min.js
-[analytics.js quickstart]: https://segment.com/docs/libraries/analytics.js/quickstart/
 
 ## License
 


### PR DESCRIPTION
analytics JS quickstart link currently taking me to android quickstart